### PR TITLE
Add check for release/2.1

### DIFF
--- a/jobs/scripts/check_version.sh
+++ b/jobs/scripts/check_version.sh
@@ -59,10 +59,13 @@ pkglist=( "coreclr:Microsoft.NETCore.Runtime.CoreCLR:version.txt"
         )
 versionlist=( "coreclr:master"
               "coreclr:release/2.0.0"
+              "coreclr:release/2.1"
               "corefx:master"
               "corefx:release/2.0.0"
+              "corefx:release/2.1"
               "core-setup:master"
               "core-setup:release/2.0.0"
+              "core-setup:release/2.1"
             )
 
 for list in ${pkglist[@]}; do


### PR DESCRIPTION
This PR adds check for release/2.1 in script in order to enable release/2.1 nupkgs build. Jobs for 2.1 were added manually, combined with this PR, it should fix MS CI.

Job generators will be updated with release/2.1 in separate pull request.