### PR TITLE
RootGenerator: cleanup workspace after job build

### DIFF
--- a/jobs/generation/RootGenerator.groovy
+++ b/jobs/generation/RootGenerator.groovy
@@ -137,6 +137,23 @@ projectLoop.each { projectName ->
       steps {
         buildDescription('',"[INFO] \${version}(\${buildid})")
       }
+
+      publishers {
+        postBuildScripts {
+            steps {
+                shell("sudo chown \$( id -u \${USER} ):\$( id -u \${USER} ) ${projectDir} -R")
+            }
+            onlyIfBuildSucceeds(false)
+            onlyIfBuildFails()
+        }
+        wsCleanup {
+          cleanWhenFailure(true)
+          cleanWhenAborted(true)
+          cleanWhenUnstable(true)
+          includePattern('**/*')
+          deleteDirectories(true)
+        }
+      }
     }
 
     // Set retention policy


### PR DESCRIPTION
We need to cleanup job's workspace after build to reduce disk usage.